### PR TITLE
Authentication and exception handling bug fixes

### DIFF
--- a/samples/OneDriveApiBrowser/FormBrowser.cs
+++ b/samples/OneDriveApiBrowser/FormBrowser.cs
@@ -330,7 +330,7 @@ namespace OneDriveApiBrowser
                     }
                     else
                     {
-                        throw;
+                        PresentOneDriveException(exception);
                     }
                 }
             }

--- a/samples/OneDriveApiBrowser/FormBrowser.cs
+++ b/samples/OneDriveApiBrowser/FormBrowser.cs
@@ -473,10 +473,15 @@ namespace OneDriveApiBrowser
 
         private static void PresentOneDriveException(Exception exception)
         {
-            string message = exception.Message;
-            if (string.IsNullOrEmpty(message) && exception.InnerException != null)
+            string message = null;
+            var oneDriveException = exception as OneDriveException;
+            if (oneDriveException == null)
             {
-                message = exception.InnerException.Message;
+                message = exception.Message;
+            }
+            else
+            {
+                message = string.Format("{0}{1}", Environment.NewLine, oneDriveException.ToString());
             }
 
             MessageBox.Show(string.Format("OneDrive reported the following error: {0}", message));

--- a/src/OneDriveSdk.Common/Authentication/AdalAuthenticationProviderBase.cs
+++ b/src/OneDriveSdk.Common/Authentication/AdalAuthenticationProviderBase.cs
@@ -27,6 +27,7 @@ namespace Microsoft.OneDrive.Sdk
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Threading.Tasks;
+    using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
     public abstract class AdalAuthenticationProviderBase : IAuthenticationProvider
     {
@@ -159,6 +160,13 @@ namespace Microsoft.OneDrive.Sdk
             {
                 this.ServiceInfo.CredentialCache.DeleteFromCache(accountSession);
             }
+        }
+
+        protected UserIdentifier GetUserIdentifierForAuthentication()
+        {
+            return string.IsNullOrEmpty(this.serviceInfo.UserId)
+                ? UserIdentifier.AnyUser
+                : new UserIdentifier(this.serviceInfo.UserId, UserIdentifierType.OptionalDisplayableId);
         }
 
         private async Task<string> GetAuthenticationTokenForResourceAsync(string resource)

--- a/src/OneDriveSdk.WinRT/Authentication/AdalAuthenticationProvider.cs
+++ b/src/OneDriveSdk.WinRT/Authentication/AdalAuthenticationProvider.cs
@@ -60,10 +60,13 @@ namespace Microsoft.OneDrive.Sdk
         protected override async Task<IAuthenticationResult> AuthenticateResourceAsync(string resource)
         {
             IAuthenticationResult authenticationResult = null;
+            var userIdentifier = string.IsNullOrEmpty(this.serviceInfo.UserId)
+                ? UserIdentifier.AnyUser
+                : new UserIdentifier(this.serviceInfo.UserId, UserIdentifierType.OptionalDisplayableId);
 
             try
             {
-                authenticationResult = await this.authenticationContextWrapper.AcquireTokenSilentAsync(resource, this.serviceInfo.AppId);
+                authenticationResult = await this.authenticationContextWrapper.AcquireTokenSilentAsync(resource, this.serviceInfo.AppId, userIdentifier);
             }
             catch (Exception)
             {
@@ -78,7 +81,9 @@ namespace Microsoft.OneDrive.Sdk
             authenticationResult = await this.authenticationContextWrapper.AcquireTokenAsync(
                 resource,
                 this.ServiceInfo.AppId,
-                new Uri(this.ServiceInfo.ReturnUrl));
+                new Uri(this.ServiceInfo.ReturnUrl),
+                PromptBehavior.Auto,
+                userIdentifier);
 
             if (authenticationResult == null || authenticationResult.Status != AuthenticationStatus.Success)
             {

--- a/src/OneDriveSdk.WinRT/Authentication/AdalAuthenticationProvider.cs
+++ b/src/OneDriveSdk.WinRT/Authentication/AdalAuthenticationProvider.cs
@@ -60,9 +60,7 @@ namespace Microsoft.OneDrive.Sdk
         protected override async Task<IAuthenticationResult> AuthenticateResourceAsync(string resource)
         {
             IAuthenticationResult authenticationResult = null;
-            var userIdentifier = string.IsNullOrEmpty(this.serviceInfo.UserId)
-                ? UserIdentifier.AnyUser
-                : new UserIdentifier(this.serviceInfo.UserId, UserIdentifierType.OptionalDisplayableId);
+            var userIdentifier = this.GetUserIdentifierForAuthentication();
 
             try
             {

--- a/src/OneDriveSdk.WinRT/Authentication/AuthenticationContextWrapper.cs
+++ b/src/OneDriveSdk.WinRT/Authentication/AuthenticationContextWrapper.cs
@@ -41,16 +41,37 @@ namespace Microsoft.OneDrive.Sdk
             this.authenticationContext = new AuthenticationContext(serviceUrl, validateAuthority, tokenCache);
         }
 
-        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId)
+        /// <summary>
+        /// Authenticates the user silently using <see cref="AuthenticationContext.AcquireToken(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="resource">The resource to authenticate against.</param>
+        /// <param name="clientId">The client ID of the application.</param>
+        /// <param name="userIdentifier">The <see cref="UserIdentifier"/> for authentication.</param>
+        /// <returns>The <see cref="IAuthenticationResult"/>.</returns>
+        public async Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId, UserIdentifier userIdentifier)
         {
-            var result = await this.authenticationContext.AcquireTokenSilentAsync(resource, clientId);
+            var result = await this.authenticationContext.AcquireTokenSilentAsync(resource, clientId, userIdentifier);
 
             return result == null ? null : new AuthenticationResultWrapper(result);
         }
 
-        public async Task<IAuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri)
+        /// <summary>
+        /// Authenticates the user using <see cref="AuthenticationContext.AcquireTokenAsync(string, string, Uri, PromptBehavior, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="resource">The resource to authenticate against.</param>
+        /// <param name="clientId">The client ID of the application.</param>
+        /// <param name="redirectUri">The redirect URI of the application.</param>
+        /// <param name="promptBehavior">The <see cref="PromptBehavior"/> for authentication.</param>
+        /// <param name="userIdentifier">The <see cref="UserIdentifier"/> for authentication.</param>
+        /// <returns>The <see cref="IAuthenticationResult"/>.</returns>
+        public async Task<IAuthenticationResult> AcquireTokenAsync(
+            string resource,
+            string clientId,
+            Uri redirectUri,
+            PromptBehavior promptBehavior,
+            UserIdentifier userIdentifier)
         {
-            var result = await this.authenticationContext.AcquireTokenAsync(resource, clientId, redirectUri);
+            var result = await this.authenticationContext.AcquireTokenAsync(resource, clientId, redirectUri, promptBehavior, userIdentifier);
 
             return result == null ? null : new AuthenticationResultWrapper(result);
         }

--- a/src/OneDriveSdk.WinRT/Authentication/IAuthenticationContextWrapper.cs
+++ b/src/OneDriveSdk.WinRT/Authentication/IAuthenticationContextWrapper.cs
@@ -22,13 +22,30 @@
 
 namespace Microsoft.OneDrive.Sdk
 {
+    using IdentityModel.Clients.ActiveDirectory;
     using System;
     using System.Threading.Tasks;
 
     public interface IAuthenticationContextWrapper
     {
-        Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId);
+        /// <summary>
+        /// Authenticates the user silently using <see cref="AuthenticationContext.AcquireToken(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="resource">The resource to authenticate against.</param>
+        /// <param name="clientId">The client ID of the application.</param>
+        /// <param name="userIdentifier">The <see cref="UserIdentifier"/> for authentication.</param>
+        /// <returns>The <see cref="IAuthenticationResult"/>.</returns>
+        Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId, UserIdentifier userIdentifier);
 
-        Task<IAuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri);
+        /// <summary>
+        /// Authenticates the user using <see cref="AuthenticationContext.AcquireTokenAsync(string, string, Uri, PromptBehavior, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="resource">The resource to authenticate against.</param>
+        /// <param name="clientId">The client ID of the application.</param>
+        /// <param name="redirectUri">The redirect URI of the application.</param>
+        /// <param name="promptBehavior">The <see cref="PromptBehavior"/> for authentication.</param>
+        /// <param name="userIdentifier">The <see cref="UserIdentifier"/> for authentication.</param>
+        /// <returns>The <see cref="IAuthenticationResult"/>.</returns>
+        Task<IAuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri, PromptBehavior promptBehavior, UserIdentifier userIdentifier);
     }
 }

--- a/src/OneDriveSdk.WinStore/Authentication/WebAuthenticationBrokerWebAuthenticationUi.cs
+++ b/src/OneDriveSdk.WinStore/Authentication/WebAuthenticationBrokerWebAuthenticationUi.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OneDrive.Sdk
             {
                 result = await this.AuthenticateAsync(requestUri, callbackUri, WebAuthenticationOptions.SilentMode);
             }
-            catch (Exception exception)
+            catch (Exception)
             {
                 // WebAuthenticationBroker can throw an exception in silent authentication mode when not using SSO and
                 // silent authentication isn't available. Swallow it and try authenticating with user prompt. Even if

--- a/src/OneDriveSdk.WindowsForms/Authentication/AdalAuthenticationProvider.cs
+++ b/src/OneDriveSdk.WindowsForms/Authentication/AdalAuthenticationProvider.cs
@@ -64,9 +64,7 @@ namespace Microsoft.OneDrive.Sdk
         {
             IAuthenticationResult authenticationResult = null;
             var clientCredential = string.IsNullOrEmpty(this.serviceInfo.ClientSecret) ? null : new ClientCredential(this.serviceInfo.AppId, this.serviceInfo.ClientSecret);
-            var userIdentifier = string.IsNullOrEmpty(this.serviceInfo.UserId)
-                ? UserIdentifier.AnyUser
-                : new UserIdentifier(this.serviceInfo.UserId, UserIdentifierType.OptionalDisplayableId);
+            var userIdentifier = this.GetUserIdentifierForAuthentication();
 
             try
             {

--- a/src/OneDriveSdk.WindowsForms/Authentication/AdalAuthenticationProvider.cs
+++ b/src/OneDriveSdk.WindowsForms/Authentication/AdalAuthenticationProvider.cs
@@ -64,12 +64,15 @@ namespace Microsoft.OneDrive.Sdk
         {
             IAuthenticationResult authenticationResult = null;
             var clientCredential = string.IsNullOrEmpty(this.serviceInfo.ClientSecret) ? null : new ClientCredential(this.serviceInfo.AppId, this.serviceInfo.ClientSecret);
+            var userIdentifier = string.IsNullOrEmpty(this.serviceInfo.UserId)
+                ? UserIdentifier.AnyUser
+                : new UserIdentifier(this.serviceInfo.UserId, UserIdentifierType.OptionalDisplayableId);
 
             try
             {
                 authenticationResult = clientCredential == null
                     ? await this.authenticationContextWrapper.AcquireTokenSilentAsync(resource, this.serviceInfo.AppId)
-                    : await this.authenticationContextWrapper.AcquireTokenSilentAsync(resource, clientCredential, UserIdentifier.AnyUser);
+                    : await this.authenticationContextWrapper.AcquireTokenSilentAsync(resource, clientCredential, userIdentifier);
             }
             catch (Exception)
             {
@@ -88,7 +91,8 @@ namespace Microsoft.OneDrive.Sdk
                         resource,
                         this.ServiceInfo.AppId,
                         new Uri(this.ServiceInfo.ReturnUrl),
-                        PromptBehavior.Always)
+                        PromptBehavior.Auto,
+                        userIdentifier)
                     : await this.authenticationContextWrapper.AcquireTokenAsync(resource, clientCredential);
             }
             catch (AdalException adalException)

--- a/src/OneDriveSdk.WindowsForms/Authentication/AuthenticationContextWrapper.cs
+++ b/src/OneDriveSdk.WindowsForms/Authentication/AuthenticationContextWrapper.cs
@@ -79,16 +79,17 @@ namespace Microsoft.OneDrive.Sdk
         }
 
         /// <summary>
-        /// Authenticates the user silently using <see cref="AuthenticationContext.AcquireToken(string, string, Uri, PromptBehavior)"/>.
+        /// Authenticates the user using <see cref="AuthenticationContext.AcquireToken(string, string, Uri, PromptBehavior, UserIdentifier)"/>.
         /// </summary>
         /// <param name="resource">The resource to authenticate against.</param>
         /// <param name="clientId">The client ID of the application.</param>
         /// <param name="redirectUri">The redirect URI of the application.</param>
         /// <param name="promptBehavior">The <see cref="PromptBehavior"/> for authentication.</param>
+        /// <param name="userIdentifier">The <see cref="UserIdentifier"/> for authentication.</param>
         /// <returns>The <see cref="IAuthenticationResult"/>.</returns>
-        public IAuthenticationResult AcquireToken(string resource, string clientId, Uri redirectUri, PromptBehavior promptBehavior)
+        public IAuthenticationResult AcquireToken(string resource, string clientId, Uri redirectUri, PromptBehavior promptBehavior, UserIdentifier userIdentifier)
         {
-            var result = this.authenticationContext.AcquireToken(resource, clientId, redirectUri, promptBehavior);
+            var result = this.authenticationContext.AcquireToken(resource, clientId, redirectUri, promptBehavior, userIdentifier);
 
             return result == null ? null : new AuthenticationResultWrapper(result);
         }

--- a/src/OneDriveSdk.WindowsForms/Authentication/IAuthenticationContextWrapper.cs
+++ b/src/OneDriveSdk.WindowsForms/Authentication/IAuthenticationContextWrapper.cs
@@ -47,14 +47,15 @@ namespace Microsoft.OneDrive.Sdk
         Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, ClientCredential clientCredential, UserIdentifier userIdentifier);
 
         /// <summary>
-        /// Authenticates the user silently using <see cref="AuthenticationContext.AcquireToken(string, string, Uri, PromptBehavior)"/>.
+        /// Authenticates the user silently using <see cref="AuthenticationContext.AcquireToken(string, string, Uri, PromptBehavior, UserIdentifier)"/>.
         /// </summary>
         /// <param name="resource">The resource to authenticate against.</param>
         /// <param name="clientId">The client ID of the application.</param>
         /// <param name="redirectUri">The redirect URI of the application.</param>
         /// <param name="promptBehavior">The <see cref="PromptBehavior"/> for authentication.</param>
+        /// <param name="userIdentifier">The <see cref="UserIdentifier"/> for authentication.</param>
         /// <returns>The <see cref="IAuthenticationResult"/>.</returns>
-        IAuthenticationResult AcquireToken(string resource, string clientId, Uri redirectUri, PromptBehavior promptBehavior);
+        IAuthenticationResult AcquireToken(string resource, string clientId, Uri redirectUri, PromptBehavior promptBehavior, UserIdentifier userIdentifier);
 
         /// <summary>
         /// Authenticates the user silently using <see cref="AuthenticationContext.AcquireTokenAsync(string, ClientCredential)"/>.

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -160,7 +160,7 @@ namespace Microsoft.OneDrive.Sdk
                 requestUriStringBuilder.Append(this.ServiceInfo.AuthenticationServiceUrl);
                 requestUriStringBuilder.AppendFormat("?{0}={1}", Constants.Authentication.RedirectUriKeyName, returnUrl);
                 requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ClientIdKeyName, this.ServiceInfo.AppId);
-                requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, string.Join("%20", this.ServiceInfo.Scopes));
+                requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, WebUtility.UrlEncode(string.Join(" ", this.ServiceInfo.Scopes));
 
                 if (!string.IsNullOrEmpty(this.ServiceInfo.UserId))
                 {

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -220,7 +220,7 @@ namespace Microsoft.OneDrive.Sdk
             var requestBodyStringBuilder = new StringBuilder();
             requestBodyStringBuilder.AppendFormat("{0}={1}", Constants.Authentication.RedirectUriKeyName, this.ServiceInfo.ReturnUrl);
             requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ClientIdKeyName, this.ServiceInfo.AppId);
-            requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, string.Join("%20", this.ServiceInfo.Scopes));
+            requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, WebUtility.UrlEncode(string.Join(" ", this.ServiceInfo.Scopes)));
             requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.RefreshTokenKeyName, refreshToken);
             requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.GrantTypeKeyName, Constants.Authentication.RefreshTokenKeyName);
 

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -160,7 +160,7 @@ namespace Microsoft.OneDrive.Sdk
                 requestUriStringBuilder.Append(this.ServiceInfo.AuthenticationServiceUrl);
                 requestUriStringBuilder.AppendFormat("?{0}={1}", Constants.Authentication.RedirectUriKeyName, returnUrl);
                 requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ClientIdKeyName, this.ServiceInfo.AppId);
-                requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, WebUtility.UrlEncode(string.Join(" ", this.ServiceInfo.Scopes));
+                requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, WebUtility.UrlEncode(string.Join(" ", this.ServiceInfo.Scopes)));
 
                 if (!string.IsNullOrEmpty(this.ServiceInfo.UserId))
                 {

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.OneDrive.Sdk
     using System.Threading.Tasks;
 
     /// <summary>
-    /// An <see cref="IAuthenticationProvider"/> implementation using the Live SDK.
+    /// A default <see cref="IAuthenticationProvider"/> implementation.
     /// </summary>
     public abstract class AuthenticationProvider : IAuthenticationProvider
     {

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -22,7 +22,9 @@
 
 namespace Microsoft.OneDrive.Sdk
 {
+    using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Text;
@@ -146,6 +148,66 @@ namespace Microsoft.OneDrive.Sdk
             }
 
             return null;
+        }
+
+        internal async Task<string> GetAuthorizationCodeAsync(string returnUrl = null)
+        {
+            if (this.ServiceInfo.WebAuthenticationUi != null)
+            {
+                returnUrl = returnUrl ?? this.ServiceInfo.ReturnUrl;
+
+                var requestUriStringBuilder = new StringBuilder();
+                requestUriStringBuilder.Append(this.ServiceInfo.AuthenticationServiceUrl);
+                requestUriStringBuilder.AppendFormat("?{0}={1}", Constants.Authentication.RedirectUriKeyName, returnUrl);
+                requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ClientIdKeyName, this.ServiceInfo.AppId);
+                requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, string.Join("%20", this.ServiceInfo.Scopes));
+
+                if (!string.IsNullOrEmpty(this.ServiceInfo.UserId))
+                {
+                    requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.UserIdKeyName, this.ServiceInfo.UserId);
+                }
+
+                requestUriStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ResponseTypeKeyName, Constants.Authentication.CodeKeyName);
+
+                var requestUri = new Uri(requestUriStringBuilder.ToString());
+
+                var authenticationResponseValues = await this.ServiceInfo.WebAuthenticationUi.AuthenticateAsync(
+                    requestUri,
+                    new Uri(returnUrl));
+                OAuthErrorHandler.ThrowIfError(authenticationResponseValues);
+
+                string code;
+                if (authenticationResponseValues != null && authenticationResponseValues.TryGetValue("code", out code))
+                {
+                    return code;
+                }
+            }
+
+            return null;
+        }
+
+        internal string GetCodeRedemptionRequestBody(string code, string returnUrl = null)
+        {
+            returnUrl = returnUrl ?? this.ServiceInfo.ReturnUrl;
+
+            var requestBodyString = string.Format(
+                "{0}={1}&{2}={3}&{4}={5}&{6}={7}&{8}=authorization_code",
+                Constants.Authentication.RedirectUriKeyName,
+                returnUrl,
+                Constants.Authentication.ClientIdKeyName,
+                this.ServiceInfo.AppId,
+                Constants.Authentication.ScopeKeyName,
+                WebUtility.UrlEncode(string.Join(" ", this.ServiceInfo.Scopes)),
+                Constants.Authentication.CodeKeyName,
+                code,
+                Constants.Authentication.GrantTypeKeyName);
+
+            if (!string.IsNullOrEmpty(this.ServiceInfo.ClientSecret))
+            {
+                requestBodyString += "&client_secret=" + this.ServiceInfo.ClientSecret;
+            }
+
+            return requestBodyString;
         }
 
         protected virtual Task<AccountSession> RefreshAccessTokenAsync(string refreshToken)

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -274,7 +274,7 @@ namespace Microsoft.OneDrive.Sdk
                 if (responseValues != null)
                 {
                     OAuthErrorHandler.ThrowIfError(responseValues);
-                    return new AccountSession(responseValues, this.ServiceInfo.AppId, AccountType.MicrosoftAccount);
+                    return new AccountSession(responseValues, this.ServiceInfo.AppId, AccountType.MicrosoftAccount) { CanSignOut = true };
                 }
 
                 throw new OneDriveException(

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -52,10 +52,7 @@ namespace Microsoft.OneDrive.Sdk
         /// <returns>The task to await.</returns>
         public virtual async Task AppendAuthHeaderAsync(HttpRequestMessage request)
         {
-            if (this.CurrentAccountSession == null || string.IsNullOrEmpty(this.CurrentAccountSession.AccessToken))
-            {
-                await this.AuthenticateAsync();
-            }
+            await this.AuthenticateAsync();
 
             if (this.CurrentAccountSession != null && !string.IsNullOrEmpty(this.CurrentAccountSession.AccessToken))
             {

--- a/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
+++ b/src/OneDriveSdk/Authentication/AuthenticationProvider.cs
@@ -190,24 +190,19 @@ namespace Microsoft.OneDrive.Sdk
         {
             returnUrl = returnUrl ?? this.ServiceInfo.ReturnUrl;
 
-            var requestBodyString = string.Format(
-                "{0}={1}&{2}={3}&{4}={5}&{6}={7}&{8}=authorization_code",
-                Constants.Authentication.RedirectUriKeyName,
-                returnUrl,
-                Constants.Authentication.ClientIdKeyName,
-                this.ServiceInfo.AppId,
-                Constants.Authentication.ScopeKeyName,
-                WebUtility.UrlEncode(string.Join(" ", this.ServiceInfo.Scopes)),
-                Constants.Authentication.CodeKeyName,
-                code,
-                Constants.Authentication.GrantTypeKeyName);
+            var requestBodyStringBuilder = new StringBuilder();
+            requestBodyStringBuilder.AppendFormat("{0}={1}", Constants.Authentication.RedirectUriKeyName, returnUrl);
+            requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ClientIdKeyName, this.ServiceInfo.AppId);
+            requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.ScopeKeyName, WebUtility.UrlEncode(string.Join(" ", this.ServiceInfo.Scopes)));
+            requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.CodeKeyName, code);
+            requestBodyStringBuilder.AppendFormat("&{0}={1}", Constants.Authentication.GrantTypeKeyName, Constants.Authentication.AuthorizationCodeGrantType);
 
             if (!string.IsNullOrEmpty(this.ServiceInfo.ClientSecret))
             {
-                requestBodyString += "&client_secret=" + this.ServiceInfo.ClientSecret;
+                requestBodyStringBuilder.AppendFormat("&client_secret={0}", this.ServiceInfo.ClientSecret);
             }
 
-            return requestBodyString;
+            return requestBodyStringBuilder.ToString();
         }
 
         protected virtual Task<AccountSession> RefreshAccessTokenAsync(string refreshToken)

--- a/src/OneDriveSdk/Authentication/IServiceInfoProvider.cs
+++ b/src/OneDriveSdk/Authentication/IServiceInfoProvider.cs
@@ -26,6 +26,9 @@ namespace Microsoft.OneDrive.Sdk
 
     public interface IServiceInfoProvider
     {
+        /// <summary>
+        /// Gets the <see cref="IAuthenticationProvider"/> for authenticating requests.
+        /// </summary>
         IAuthenticationProvider AuthenticationProvider { get; }
 
         /// <summary>

--- a/src/OneDriveSdk/Authentication/ServiceInfoProvider.cs
+++ b/src/OneDriveSdk/Authentication/ServiceInfoProvider.cs
@@ -63,7 +63,15 @@ namespace Microsoft.OneDrive.Sdk
             this.webAuthenticationUi = webAuthenticationUi;
         }
 
+        /// <summary>
+        /// Gets the <see cref="IAuthenticationProvider"/> for authenticating requests.
+        /// </summary>
         public IAuthenticationProvider AuthenticationProvider { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the sign in name of the authenticating user.
+        /// </summary>
+        public string UserSignInName { get; set; }
 
         /// <summary>
         /// Generates the <see cref="ServiceInfo"/> for the current application configuration.
@@ -89,6 +97,7 @@ namespace Microsoft.OneDrive.Sdk
                     HttpProvider = httpProvider,
                     ReturnUrl = appConfig.MicrosoftAccountReturnUrl,
                     Scopes = appConfig.MicrosoftAccountScopes,
+                    UserId = this.UserSignInName,
                     WebAuthenticationUi = this.webAuthenticationUi,
                 };
 
@@ -104,6 +113,7 @@ namespace Microsoft.OneDrive.Sdk
                 CredentialCache = credentialCache,
                 HttpProvider = httpProvider,
                 ReturnUrl = appConfig.ActiveDirectoryReturnUrl,
+                UserId = this.UserSignInName,
             };
             
             return Task.FromResult<ServiceInfo>(activeDirectoryServiceInfo);

--- a/src/OneDriveSdk/Constants.cs
+++ b/src/OneDriveSdk/Constants.cs
@@ -32,6 +32,8 @@ namespace Microsoft.OneDrive.Sdk
 
             public const string AuthenticationCancelled = "authentication_cancelled";
 
+            public const string AuthorizationCodeGrantType = "authorization_code";
+
             public const string AuthorizationServiceKey = "authorization_service";
 
             public const string ClientIdKeyName = "client_id";

--- a/src/OneDriveSdk/Constants.cs
+++ b/src/OneDriveSdk/Constants.cs
@@ -100,6 +100,8 @@ namespace Microsoft.OneDrive.Sdk
             public const string FormUrlEncodedContentType = "application/x-www-form-urlencoded";
 
             public const string SdkVersionHeaderValue = "SDK-Version=CSharp-v{0}";
+
+            public const string ThrowSiteHeaderName = "X-ThrowSite";
         }
 
         public static class Url

--- a/src/OneDriveSdk/Exceptions/Error.cs
+++ b/src/OneDriveSdk/Exceptions/Error.cs
@@ -39,6 +39,9 @@ namespace Microsoft.OneDrive.Sdk
         [DataMember(Name = "message", IsRequired = false, EmitDefaultValue = false)]
         public string Message { get; set; }
 
+        [DataMember(Name = "throwSite", IsRequired = false, EmitDefaultValue = false)]
+        public string ThrowSite { get; set; }
+
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
     }

--- a/src/OneDriveSdk/Exceptions/Error.cs
+++ b/src/OneDriveSdk/Exceptions/Error.cs
@@ -22,10 +22,11 @@
 
 namespace Microsoft.OneDrive.Sdk
 {
-    using Newtonsoft.Json;
+    using System;
     using System.Collections.Generic;
-    using System.Net;
     using System.Runtime.Serialization;
+    using System.Text;
+    using Newtonsoft.Json;
 
     [DataContract]
     public class Error
@@ -44,5 +45,38 @@ namespace Microsoft.OneDrive.Sdk
 
         [JsonExtensionData]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        public override string ToString()
+        {
+            var errorStringBuilder = new StringBuilder();
+
+            if (!string.IsNullOrEmpty(this.Code))
+            {
+                errorStringBuilder.AppendFormat("Code: {0}", this.Code);
+                errorStringBuilder.Append(Environment.NewLine);
+            }
+
+            if (!string.IsNullOrEmpty(this.ThrowSite))
+            {
+                errorStringBuilder.AppendFormat("Throw site: {0}", this.ThrowSite);
+                errorStringBuilder.Append(Environment.NewLine);
+            }
+
+            if (!string.IsNullOrEmpty(this.Message))
+            {
+                errorStringBuilder.AppendFormat("Message: {0}", this.Message);
+                errorStringBuilder.Append(Environment.NewLine);
+            }
+
+            if (this.InnerError != null)
+            {
+                errorStringBuilder.Append(Environment.NewLine);
+                errorStringBuilder.Append("Inner error");
+                errorStringBuilder.Append(Environment.NewLine);
+                errorStringBuilder.Append(this.InnerError.ToString());
+            }
+
+            return errorStringBuilder.ToString();
+        }
     }
 }

--- a/src/OneDriveSdk/Exceptions/OneDriveException.cs
+++ b/src/OneDriveSdk/Exceptions/OneDriveException.cs
@@ -55,5 +55,15 @@ namespace Microsoft.OneDrive.Sdk
 
             return false;
         }
+
+        public override string ToString()
+        {
+            if (this.Error != null)
+            {
+                return this.Error.ToString();
+            }
+
+            return null;
+        }
     }
 }

--- a/src/OneDriveSdk/Requests/AsyncMonitor.cs
+++ b/src/OneDriveSdk/Requests/AsyncMonitor.cs
@@ -45,7 +45,7 @@ namespace Microsoft.OneDrive.Sdk
         {
             while (!cancellationToken.IsCancellationRequested)
             {
-                if (!this.client.IsAuthenticated)
+                if (!this.client.IsAuthenticated || this.client.AuthenticationProvider.CurrentAccountSession.IsExpiring())
                 {
                     await this.client.AuthenticateAsync();
                 }

--- a/src/OneDriveSdk/Requests/BaseClient.cs
+++ b/src/OneDriveSdk/Requests/BaseClient.cs
@@ -52,6 +52,9 @@ namespace Microsoft.OneDrive.Sdk
             this.serviceInfoProvider = serviceInfoProvider ?? new ServiceInfoProvider();
         }
 
+        /// <summary>
+        /// Gets the <see cref="IAuthenticationProvider"/> for authenticating requests.
+        /// </summary>
         public IAuthenticationProvider AuthenticationProvider
         {
             get
@@ -87,6 +90,9 @@ namespace Microsoft.OneDrive.Sdk
             }
         }
 
+        /// <summary>
+        /// Gets the <see cref="ClientType"/> of the client.
+        /// </summary>
         public ClientType ClientType { get; private set; }
 
         /// <summary>

--- a/src/OneDriveSdk/Requests/BaseRequest.cs
+++ b/src/OneDriveSdk/Requests/BaseRequest.cs
@@ -281,6 +281,16 @@ namespace Microsoft.OneDrive.Sdk
         /// <returns>The request URL minus query string.</returns>
         private string InitializeUrl(string requestUrl)
         {
+            if (string.IsNullOrEmpty(requestUrl))
+            {
+                throw new OneDriveException(
+                    new Error
+                    {
+                        Code = OneDriveErrorCode.InvalidRequest.ToString(),
+                        Message = "Base URL is not initialized for the request.",
+                    });
+            }
+
             var uri = new Uri(requestUrl);
             
             if (!string.IsNullOrEmpty(uri.Query))

--- a/tests/Test.OneDriveSdk.WinRT/Authentication/AdalAuthenticationProviderTests.cs
+++ b/tests/Test.OneDriveSdk.WinRT/Authentication/AdalAuthenticationProviderTests.cs
@@ -90,119 +90,49 @@ namespace Test.OneDriveSdk.WinRT
         [TestMethod]
         public async Task AuthenticateAsync_AuthenticateSilentlyWithDiscoveryService()
         {
-            const string serviceResourceId = "https://localhost/resource/";
+            await this.AuthenticateAsync_AuthenticateSilentlyWithDiscoveryService_Base(false);
+        }
 
-            var authenticationResult = new MockAuthenticationResult
-            {
-                AccessToken = "token",
-                AccessTokenType = "type",
-                ExpiresOn = DateTimeOffset.UtcNow,
-                Status = AuthenticationStatus.Success,
-            };
-
-            await this.AuthenticateAsync_AuthenticateWithDiscoveryService(
-                authenticationResult,
-                (string resource, string clientId, Uri redirectUri) =>
-                {
-                    switch (resource)
-                    {
-                        case (Constants.Authentication.ActiveDirectoryDiscoveryResource):
-                            return new MockAuthenticationResult { AccessToken = "discoveryServiceToken" };
-                        default:
-                            return null;
-                    }
-                },
-                (string resource, string clientId) =>
-                {
-                    switch (resource)
-                    {
-                        case (serviceResourceId):
-                            return authenticationResult;
-                        case (Constants.Authentication.ActiveDirectoryDiscoveryResource):
-                            throw new Exception();
-                        default:
-                            return null;
-                    }
-                });
+        [TestMethod]
+        public async Task AuthenticateAsync_AuthenticateSilentlyWithDiscoveryService_UserSignInNameSet()
+        {
+            await this.AuthenticateAsync_AuthenticateSilentlyWithDiscoveryService_Base(true);
         }
 
         [TestMethod]
         public async Task AuthenticateAsync_AuthenticateWithDiscoveryService()
         {
-            const string serviceResourceId = "https://localhost/resource/";
+            await this.AuthenticateAsync_AuthenticateWithDiscoveryService_Base(false);
+        }
 
-            var authenticationResult = new MockAuthenticationResult
-            {
-                AccessToken = "token",
-                AccessTokenType = "type",
-                ExpiresOn = DateTimeOffset.UtcNow,
-                Status = AuthenticationStatus.Success,
-            };
-
-            await this.AuthenticateAsync_AuthenticateWithDiscoveryService(
-                authenticationResult,
-                (string resource, string clientId, Uri redirectUri) =>
-                    {
-                        switch (resource)
-                        {
-                            case (serviceResourceId):
-                                return authenticationResult;
-                            case (Constants.Authentication.ActiveDirectoryDiscoveryResource):
-                                return new MockAuthenticationResult { AccessToken = "discoveryServiceToken" };
-                            default:
-                                return null;
-                        }
-                    },
-                (string resource, string clientId) =>
-                    {
-                        throw new Exception();
-                    });
+        [TestMethod]
+        public async Task AuthenticateAsync_AuthenticateWithDiscoveryService_UserSignInNameSet()
+        {
+            await this.AuthenticateAsync_AuthenticateWithDiscoveryService_Base(true);
         }
 
         [TestMethod]
         public async Task AuthenticateAsync_AuthenticateSilentlyWithoutDiscoveryService()
         {
-            var silentAuthenticationResult = new MockAuthenticationResult
-            {
-                AccessToken = "token",
-                AccessTokenType = "type",
-                ExpiresOn = DateTimeOffset.UtcNow,
-                Status = AuthenticationStatus.Success,
-            };
+            await this.AuthenticateAsync_AuthenticateSilentlyWithoutDiscoveryService_Base(false);
+        }
 
-            await this.AuthenticateAsync_AuthenticateWithoutDiscoveryService(
-                silentAuthenticationResult,
-                null,
-                (string resource, string clientId) =>
-                {
-                    return silentAuthenticationResult;
-                });
+        [TestMethod]
+        public async Task AuthenticateAsync_AuthenticateSilentlyWithoutDiscoveryService_UserSignInNameSet()
+        {
+            await this.AuthenticateAsync_AuthenticateSilentlyWithoutDiscoveryService_Base(true);
         }
 
         [TestMethod]
         public async Task AuthenticateAsync_AuthenticateWithoutDiscoveryService()
         {
-            this.serviceInfo.ServiceResource = "https://resource/";
-            this.serviceInfo.BaseUrl = "https://localhost";
+            await this.AuthenticateAsync_AuthenticateWithoutDiscoveryService_Base(false);
+        }
 
-            var authenticationResult = new MockAuthenticationResult
-            {
-                AccessToken = "token",
-                AccessTokenType = "type",
-                ExpiresOn = DateTimeOffset.UtcNow,
-                Status = AuthenticationStatus.Success,
-            };
-
-            await this.AuthenticateAsync_AuthenticateWithoutDiscoveryService(
-                authenticationResult,
-                (string resource, string clientId, Uri redirectUri) =>
-                {
-                    return authenticationResult;
-                },
-                (string resource, string clientId) =>
-                {
-                    throw new Exception();
-                });
+        [TestMethod]
+        public async Task AuthenticateAsync_AuthenticateWithoutDiscoveryService_UserSignInNameSet()
+        {
+            await this.AuthenticateAsync_AuthenticateWithoutDiscoveryService_Base(true);
         }
 
         [TestMethod]
@@ -220,11 +150,11 @@ namespace Test.OneDriveSdk.WinRT
             try
             {
                 await this.AuthenticateWithDiscoveryService(
-                    (string resource, string clientId, Uri redirectUri) =>
+                    (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
                     {
                         return authenticationResult;
                     },
-                    (string resource, string clientId) =>
+                    (string resource, string clientId, UserIdentifier userIdentifier) =>
                     {
                         throw new Exception();
                     });
@@ -253,7 +183,7 @@ namespace Test.OneDriveSdk.WinRT
             try
             {
                 await this.AuthenticateWithDiscoveryService(
-                    (string resource, string clientId, Uri redirectUri) =>
+                    (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
                     {
                         switch (resource)
                         {
@@ -263,7 +193,7 @@ namespace Test.OneDriveSdk.WinRT
                                 return null;
                         }
                     },
-                    (string resource, string clientId) =>
+                    (string resource, string clientId, UserIdentifier userIdentifier) =>
                     {
                         throw new Exception();
                     },
@@ -304,7 +234,7 @@ namespace Test.OneDriveSdk.WinRT
             try
             {
                 await this.AuthenticateWithDiscoveryService(
-                    (string resource, string clientId, Uri redirectUri) =>
+                    (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
                     {
                         switch (resource)
                         {
@@ -314,7 +244,7 @@ namespace Test.OneDriveSdk.WinRT
                                 return null;
                         }
                     },
-                    (string resource, string clientId) =>
+                    (string resource, string clientId, UserIdentifier userIdentifier) =>
                     {
                         throw new Exception();
                     },
@@ -355,7 +285,7 @@ namespace Test.OneDriveSdk.WinRT
             try
             {
                 await this.AuthenticateWithDiscoveryService(
-                    (string resource, string clientId, Uri redirectUri) =>
+                    (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
                     {
                         switch (resource)
                         {
@@ -365,7 +295,7 @@ namespace Test.OneDriveSdk.WinRT
                                 return null;
                         }
                     },
-                    (string resource, string clientId) =>
+                    (string resource, string clientId, UserIdentifier userIdentifier) =>
                     {
                         throw new Exception();
                     },
@@ -393,11 +323,11 @@ namespace Test.OneDriveSdk.WinRT
             try
             {
                 await this.AuthenticateWithDiscoveryService(
-                    (string resource, string clientId, Uri redirectUri) =>
+                    (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
                     {
                         return null;
                     },
-                    (string resource, string clientId) =>
+                    (string resource, string clientId, UserIdentifier userIdentifier) =>
                     {
                         throw new Exception();
                     });
@@ -622,6 +552,186 @@ namespace Test.OneDriveSdk.WinRT
             }
 
             return accountSession;
+        }
+
+        private async Task AuthenticateAsync_AuthenticateSilentlyWithDiscoveryService_Base(bool setUserSignInName)
+        {
+            const string serviceResourceId = "https://localhost/resource/";
+
+            if (setUserSignInName)
+            {
+                this.serviceInfo.UserId = "email";
+            }
+
+            var authenticationResult = new MockAuthenticationResult
+            {
+                AccessToken = "token",
+                AccessTokenType = "type",
+                ExpiresOn = DateTimeOffset.UtcNow,
+                Status = AuthenticationStatus.Success,
+            };
+
+            await this.AuthenticateAsync_AuthenticateWithDiscoveryService(
+                authenticationResult,
+                (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
+                {
+                    if (setUserSignInName)
+                    {
+                        Assert.AreEqual(this.serviceInfo.UserId, userIdentifier.Id, "Unexpected user identifier.");
+                    }
+                    else
+                    {
+                        Assert.AreEqual(UserIdentifier.AnyUser, userIdentifier, "Unexpected user identifier.");
+                    }
+
+                    switch (resource)
+                    {
+                        case (Constants.Authentication.ActiveDirectoryDiscoveryResource):
+                            return new MockAuthenticationResult { AccessToken = "discoveryServiceToken" };
+                        default:
+                            return null;
+                    }
+                },
+                (string resource, string clientId, UserIdentifier userIdentifier) =>
+                {
+                    if (setUserSignInName)
+                    {
+                        Assert.AreEqual(this.serviceInfo.UserId, userIdentifier.Id, "Unexpected user identifier.");
+                    }
+                    else
+                    {
+                        Assert.AreEqual(UserIdentifier.AnyUser, userIdentifier, "Unexpected user identifier.");
+                    }
+
+                    switch (resource)
+                    {
+                        case (serviceResourceId):
+                            return authenticationResult;
+                        case (Constants.Authentication.ActiveDirectoryDiscoveryResource):
+                            throw new Exception();
+                        default:
+                            return null;
+                    }
+                });
+        }
+
+
+        public async Task AuthenticateAsync_AuthenticateSilentlyWithoutDiscoveryService_Base(bool setUserSignInName)
+        {
+            if (setUserSignInName)
+            {
+                this.serviceInfo.UserId = "email";
+            }
+
+            var silentAuthenticationResult = new MockAuthenticationResult
+            {
+                AccessToken = "token",
+                AccessTokenType = "type",
+                ExpiresOn = DateTimeOffset.UtcNow,
+                Status = AuthenticationStatus.Success,
+            };
+
+            await this.AuthenticateAsync_AuthenticateWithoutDiscoveryService(
+                silentAuthenticationResult,
+                null,
+                (string resource, string clientId, UserIdentifier userIdentifier) =>
+                {
+                    if (setUserSignInName)
+                    {
+                        Assert.AreEqual(this.serviceInfo.UserId, userIdentifier.Id, "Unexpected user identifier.");
+                    }
+                    else
+                    {
+                        Assert.AreEqual(UserIdentifier.AnyUser, userIdentifier, "Unexpected user identifier.");
+                    }
+
+                    return silentAuthenticationResult;
+                });
+        }
+
+        public async Task AuthenticateAsync_AuthenticateWithDiscoveryService_Base(bool setUserSignInName)
+        {
+            const string serviceResourceId = "https://localhost/resource/";
+
+            if (setUserSignInName)
+            {
+                this.serviceInfo.UserId = "email";
+            }
+
+            var authenticationResult = new MockAuthenticationResult
+            {
+                AccessToken = "token",
+                AccessTokenType = "type",
+                ExpiresOn = DateTimeOffset.UtcNow,
+                Status = AuthenticationStatus.Success,
+            };
+
+            await this.AuthenticateAsync_AuthenticateWithDiscoveryService(
+                authenticationResult,
+                (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
+                {
+                    if (setUserSignInName)
+                    {
+                        Assert.AreEqual(this.serviceInfo.UserId, userIdentifier.Id, "Unexpected user identifier.");
+                    }
+                    else
+                    {
+                        Assert.AreEqual(UserIdentifier.AnyUser, userIdentifier, "Unexpected user identifier.");
+                    }
+
+                    switch (resource)
+                    {
+                        case (serviceResourceId):
+                            return authenticationResult;
+                        case (Constants.Authentication.ActiveDirectoryDiscoveryResource):
+                            return new MockAuthenticationResult { AccessToken = "discoveryServiceToken" };
+                        default:
+                            return null;
+                    }
+                },
+                (string resource, string clientId, UserIdentifier userIdentifier) =>
+                {
+                    throw new Exception();
+                });
+        }
+
+        private async Task AuthenticateAsync_AuthenticateWithoutDiscoveryService_Base(bool setUserSignInName)
+        {
+            this.serviceInfo.ServiceResource = "https://resource/";
+            this.serviceInfo.BaseUrl = "https://localhost";
+
+            if (setUserSignInName)
+            {
+                this.serviceInfo.UserId = "email";
+            }
+
+            var authenticationResult = new MockAuthenticationResult
+            {
+                AccessToken = "token",
+                AccessTokenType = "type",
+                ExpiresOn = DateTimeOffset.UtcNow,
+                Status = AuthenticationStatus.Success,
+            };
+
+            await this.AuthenticateAsync_AuthenticateWithoutDiscoveryService(
+                authenticationResult,
+                (string resource, string clientId, Uri redirectUri, UserIdentifier userIdentifier) =>
+                {
+                    if (setUserSignInName)
+                    {
+                        Assert.AreEqual(this.serviceInfo.UserId, userIdentifier.Id, "Unexpected user identifier.");
+                    }
+                    else
+                    {
+                        Assert.AreEqual(UserIdentifier.AnyUser, userIdentifier, "Unexpected user identifier.");
+                    }
+
+                    return authenticationResult;
+                },
+                (string resource, string clientId, UserIdentifier userIdentifier) =>
+                {
+                    throw new Exception();
+                });
         }
 
         private void OnAuthenticateAsync_SignOut(Uri requestUri, Uri callbackUri)

--- a/tests/Test.OneDriveSdk.WinRT/Mocks/MockAuthenticationContextWrapper.cs
+++ b/tests/Test.OneDriveSdk.WinRT/Mocks/MockAuthenticationContextWrapper.cs
@@ -25,6 +25,7 @@ namespace Test.OneDriveSdk.WinRT.Mocks
     using System;
     using System.Threading.Tasks;
     using Microsoft.OneDrive.Sdk;
+    using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
     public class MockAuthenticationContextWrapper : IAuthenticationContextWrapper
     {
@@ -34,12 +35,17 @@ namespace Test.OneDriveSdk.WinRT.Mocks
         public AuthenticationResultCallback AcquireTokenAsyncCallback { get; set; }
         public AuthenticationResultSilentCallback AcquireTokenSilentAsyncCallback { get; set; }
 
-        public Task<IAuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri)
+        public Task<IAuthenticationResult> AcquireTokenAsync(
+            string resource,
+            string clientId,
+            Uri redirectUri,
+            PromptBehavior promptBehavior,
+            UserIdentifier userIdentifier)
         {
             return Task.FromResult(this.AcquireTokenAsyncCallback(resource, clientId, redirectUri));
         }
 
-        public Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId)
+        public Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId, UserIdentifier userIdentifier)
         {
             return Task.FromResult(this.AcquireTokenSilentAsyncCallback(resource, clientId));
         }

--- a/tests/Test.OneDriveSdk.WinRT/Mocks/MockAuthenticationContextWrapper.cs
+++ b/tests/Test.OneDriveSdk.WinRT/Mocks/MockAuthenticationContextWrapper.cs
@@ -29,8 +29,16 @@ namespace Test.OneDriveSdk.WinRT.Mocks
 
     public class MockAuthenticationContextWrapper : IAuthenticationContextWrapper
     {
-        public delegate IAuthenticationResult AuthenticationResultCallback(string resource, string clientId, Uri redirectUri);
-        public delegate IAuthenticationResult AuthenticationResultSilentCallback(string resource, string clientId);
+        public delegate IAuthenticationResult AuthenticationResultCallback(
+            string resource,
+            string clientId,
+            Uri redirectUri,
+            UserIdentifier userIdentifier);
+
+        public delegate IAuthenticationResult AuthenticationResultSilentCallback(
+            string resource,
+            string clientId,
+            UserIdentifier userIdentifier);
 
         public AuthenticationResultCallback AcquireTokenAsyncCallback { get; set; }
         public AuthenticationResultSilentCallback AcquireTokenSilentAsyncCallback { get; set; }
@@ -42,12 +50,12 @@ namespace Test.OneDriveSdk.WinRT.Mocks
             PromptBehavior promptBehavior,
             UserIdentifier userIdentifier)
         {
-            return Task.FromResult(this.AcquireTokenAsyncCallback(resource, clientId, redirectUri));
+            return Task.FromResult(this.AcquireTokenAsyncCallback(resource, clientId, redirectUri, userIdentifier));
         }
 
         public Task<IAuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId, UserIdentifier userIdentifier)
         {
-            return Task.FromResult(this.AcquireTokenSilentAsyncCallback(resource, clientId));
+            return Task.FromResult(this.AcquireTokenSilentAsyncCallback(resource, clientId, userIdentifier));
         }
     }
 }

--- a/tests/Test.OneDriveSdk.WinRT/Mocks/MockSerializer.cs
+++ b/tests/Test.OneDriveSdk.WinRT/Mocks/MockSerializer.cs
@@ -22,35 +22,54 @@
 
 namespace Test.OneDriveSdk.WinRT.Mocks
 {
-    using System.Net.Http;
-    using System.Threading.Tasks;
+    using System.IO;
 
     using Microsoft.OneDrive.Sdk;
 
-    public delegate void SendAsyncCallback(HttpRequestMessage request);
+    public delegate void DeserializeObjectStreamCallback(Stream stream);
+    public delegate void DeserializeObjectStringCallback(string inputString);
+    public delegate string SerializeObjectCallback(object serializableObject);
 
-    public class MockHttpProvider : IHttpProvider
+    public class MockSerializer : ISerializer
     {
-        private HttpResponseMessage httpResponseMessage;
+        public object DeserializeObjectResponse { get; set; }
 
-        public MockHttpProvider(HttpResponseMessage httpResponseMessage, ISerializer serializer = null)
+        public string SerializeObjectResponse { get; set; }
+
+        public DeserializeObjectStreamCallback OnDeserializeObjectStream { get; set; }
+
+        public DeserializeObjectStringCallback OnDeserializeObjectString { get; set; }
+
+        public SerializeObjectCallback OnSerializeObject { get; set; }
+
+        public T DeserializeObject<T>(string inputString)
         {
-            this.httpResponseMessage = httpResponseMessage;
-            this.Serializer = serializer;
-        }
-
-        public SendAsyncCallback OnSendAsync { get; set; }
-
-        public ISerializer Serializer { get; private set; }
-
-        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
-        {
-            if (this.OnSendAsync != null)
+            if (this.OnDeserializeObjectString != null)
             {
-                this.OnSendAsync(request);
+                this.OnDeserializeObjectString(inputString);
             }
 
-            return Task.FromResult(this.httpResponseMessage);
+            return (T)this.DeserializeObjectResponse;
+        }
+
+        public T DeserializeObject<T>(Stream stream)
+        {
+            if (this.OnDeserializeObjectStream != null)
+            {
+                this.OnDeserializeObjectStream(stream);
+            }
+
+            return (T)this.DeserializeObjectResponse;
+        }
+
+        public string SerializeObject(object serializeableObject)
+        {
+            if (this.OnSerializeObject != null)
+            {
+                this.OnSerializeObject(serializeableObject);
+            }
+
+            return this.SerializeObjectResponse;
         }
     }
 }

--- a/tests/Test.OneDriveSdk.WinRT/Test.OneDriveSdk.WinRT.csproj
+++ b/tests/Test.OneDriveSdk.WinRT/Test.OneDriveSdk.WinRT.csproj
@@ -121,6 +121,7 @@
     <Compile Include="Mocks\MockAdalCredentialCache.cs" />
     <Compile Include="Mocks\MockAuthenticationResult.cs" />
     <Compile Include="Mocks\MockCredentialCache.cs" />
+    <Compile Include="Mocks\MockSerializer.cs" />
     <Compile Include="Mocks\MockHttpProvider.cs" />
     <Compile Include="Mocks\MockWebAuthenticationUi.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/tests/Test.OneDriveSdk.WindowsForms/Authentication/AdalAuthenticationProviderTests.cs
+++ b/tests/Test.OneDriveSdk.WindowsForms/Authentication/AdalAuthenticationProviderTests.cs
@@ -201,7 +201,8 @@ namespace Test.OneDriveSdk.WindowsForms.Authentication
                 It.Is<string>(resource => resource.Equals(serviceResourceId)),
                 It.Is<string>(clientId => clientId.Equals(this.serviceInfo.AppId)),
                 It.Is<Uri>(returnUri => returnUri.ToString().Equals(this.serviceInfo.ReturnUrl)),
-                PromptBehavior.Always)).Returns(mockAuthenticationResult.Object);
+                PromptBehavior.Auto,
+                UserIdentifier.AnyUser)).Returns(mockAuthenticationResult.Object);
 
             await this.AuthenticateAsync_AuthenticateWithDiscoveryService(
                 mockAuthenticationContextWrapper,
@@ -229,7 +230,8 @@ namespace Test.OneDriveSdk.WindowsForms.Authentication
                 It.Is<string>(resource => resource.Equals(serviceResourceId)),
                 It.Is<string>(clientId => clientId.Equals(this.serviceInfo.AppId)),
                 It.Is<Uri>(returnUri => returnUri.ToString().Equals(this.serviceInfo.ReturnUrl)),
-                PromptBehavior.Always)).Returns(mockAuthenticationResult.Object);
+                PromptBehavior.Auto,
+                UserIdentifier.AnyUser)).Returns(mockAuthenticationResult.Object);
 
             await this.AuthenticateAsync_AuthenticateWithoutDiscoveryService(
                 mockAuthenticationContextWrapper.Object,
@@ -254,7 +256,8 @@ namespace Test.OneDriveSdk.WindowsForms.Authentication
                 It.Is<string>(resource => resource.Equals(serviceResourceId)),
                 It.Is<string>(clientId => clientId.Equals(this.serviceInfo.AppId)),
                 It.Is<Uri>(returnUri => returnUri.ToString().Equals(this.serviceInfo.ReturnUrl)),
-                PromptBehavior.Always)).Throws(innerException);
+                PromptBehavior.Auto,
+                UserIdentifier.AnyUser)).Throws(innerException);
             
             try
             {
@@ -429,7 +432,8 @@ namespace Test.OneDriveSdk.WindowsForms.Authentication
                 It.Is<string>(resource => resource.Equals(serviceResourceId)),
                 It.Is<string>(clientId => clientId.Equals(this.serviceInfo.AppId)),
                 It.Is<Uri>(returnUri => returnUri.ToString().Equals(this.serviceInfo.ReturnUrl)),
-                PromptBehavior.Always)).Returns((IAuthenticationResult)null);
+                PromptBehavior.Auto,
+                UserIdentifier.AnyUser)).Returns((IAuthenticationResult)null);
 
             try
             {
@@ -614,7 +618,8 @@ namespace Test.OneDriveSdk.WindowsForms.Authentication
                 It.Is<string>(resource => resource.Equals(Constants.Authentication.ActiveDirectoryDiscoveryResource)),
                 It.Is<string>(clientId => clientId.Equals(this.serviceInfo.AppId)),
                 It.Is<Uri>(returnUri => returnUri.ToString().Equals(this.serviceInfo.ReturnUrl)),
-                PromptBehavior.Always)).Returns(mockAuthenticationResult.Object);
+                PromptBehavior.Auto,
+                UserIdentifier.AnyUser)).Returns(mockAuthenticationResult.Object);
 
             if (discoveryServiceResponse == null)
             {

--- a/tests/Test.OneDriveSdk/Authentication/ServiceInfoProviderTests.cs
+++ b/tests/Test.OneDriveSdk/Authentication/ServiceInfoProviderTests.cs
@@ -55,7 +55,10 @@ namespace Test.OneDriveSdk.Authentication
             this.httpResponseMessage = new HttpResponseMessage();
             this.httpProvider = new MockHttpProvider(this.httpResponseMessage);
             this.webAuthenticationUi = new MockWebAuthenticationUi();
-            this.serviceInfoProvider = new ServiceInfoProvider(this.webAuthenticationUi.Object);
+            this.serviceInfoProvider = new ServiceInfoProvider(this.webAuthenticationUi.Object)
+            {
+                UserSignInName = "email",
+            };
         }
 
         [TestCleanup]
@@ -82,7 +85,7 @@ namespace Test.OneDriveSdk.Authentication
             Assert.AreEqual(this.appConfig.MicrosoftAccountClientSecret, serviceInfo.ClientSecret, "Unexpected client secret set.");
             Assert.AreEqual(this.appConfig.MicrosoftAccountReturnUrl, serviceInfo.ReturnUrl, "Unexpected return URL set.");
             Assert.AreEqual(this.appConfig.MicrosoftAccountScopes, serviceInfo.Scopes, "Unexpected scopes set.");
-            Assert.AreEqual(this.credentialCache.Object, serviceInfo.CredentialCache, "Unexpected credential cache set.");
+            Assert.AreEqual("email", serviceInfo.UserId, "Unexpected user ID set.");
             Assert.AreEqual(this.webAuthenticationUi.Object, serviceInfo.WebAuthenticationUi, "Unexpected web UI set.");
         }
 

--- a/tests/Test.OneDriveSdk/Requests/AsyncMonitorTests.cs
+++ b/tests/Test.OneDriveSdk/Requests/AsyncMonitorTests.cs
@@ -33,7 +33,8 @@ namespace Test.OneDriveSdk.Requests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Mocks;
     using Moq;
-    
+    using System;
+
     [TestClass]
     public class AsyncMonitorTests
     {
@@ -134,6 +135,9 @@ namespace Test.OneDriveSdk.Requests
                     It.IsAny<Stream>()))
                 .Returns(new AsyncOperationStatus { Status = "cancelled" });
             this.oneDriveClient.SetupGet(client => client.IsAuthenticated).Returns(true);
+            this.authenticationProvider
+                .SetupGet(provider => provider.CurrentAccountSession)
+                .Returns(new AccountSession { ExpiresOnUtc = DateTimeOffset.UtcNow.AddMinutes(60) });
 
             using (var stringContent = new StringContent("content"))
             {
@@ -154,6 +158,9 @@ namespace Test.OneDriveSdk.Requests
                     It.IsAny<Stream>()))
                 .Returns(new AsyncOperationStatus { Status = "deleteFailed" });
             this.oneDriveClient.SetupGet(client => client.IsAuthenticated).Returns(true);
+            this.authenticationProvider
+                .SetupGet(provider => provider.CurrentAccountSession)
+                .Returns(new AccountSession { ExpiresOnUtc = DateTimeOffset.UtcNow.AddMinutes(60) });
 
             using (var stringContent = new StringContent("content"))
             {
@@ -186,7 +193,10 @@ namespace Test.OneDriveSdk.Requests
                     });
 
             this.oneDriveClient.SetupGet(client => client.IsAuthenticated).Returns(true);
-            
+            this.authenticationProvider
+                .SetupGet(provider => provider.CurrentAccountSession)
+                .Returns(new AccountSession { ExpiresOnUtc = DateTimeOffset.UtcNow.AddMinutes(60) });
+
             using (var stringContent = new StringContent("content"))
             {
                 this.httpResponseMessage.Content = stringContent;
@@ -214,6 +224,9 @@ namespace Test.OneDriveSdk.Requests
                     It.IsAny<Stream>()))
                 .Returns((AsyncOperationStatus)null);
             this.oneDriveClient.SetupGet(client => client.IsAuthenticated).Returns(true);
+            this.authenticationProvider
+                .SetupGet(provider => provider.CurrentAccountSession)
+                .Returns(new AccountSession { ExpiresOnUtc = DateTimeOffset.UtcNow.AddMinutes(60) });
 
             using (var stringContent = new StringContent("content"))
             {

--- a/tests/Test.OneDriveSdk/Requests/BaseRequestTests.cs
+++ b/tests/Test.OneDriveSdk/Requests/BaseRequestTests.cs
@@ -38,6 +38,22 @@ namespace Test.OneDriveSdk.Requests
     public class BaseRequestTests : RequestTestBase
     {
         [TestMethod]
+        [ExpectedException(typeof(OneDriveException))]
+        public void BaseRequest_InitializeWithEmptyBaseUrl()
+        {
+            try
+            {
+                var baseRequest = new BaseRequest(null, this.oneDriveClient);
+            }
+            catch (OneDriveException exception)
+            {
+                Assert.AreEqual(OneDriveErrorCode.InvalidRequest.ToString(), exception.Error.Code, "Unexpected error code.");
+                Assert.AreEqual("Base URL is not initialized for the request.", exception.Error.Message, "Unexpected error message.");
+                throw;
+            }
+        }
+
+        [TestMethod]
         public void BaseRequest_InitializeWithQueryStringAndOptions()
         {
             var baseUrl = string.Format(Constants.Authentication.OneDriveConsumerBaseUrlFormatString, "v1.0") + "/drive/items/id";


### PR DESCRIPTION
- Fix re-auth for expired tokens
- Use code flow instead of token flow for WebAuthenticationBroker flow so refresh tokens will be returned
- Enable a way to set user's sign in name on the service info provider for SSO scenarios
- Set throw site in OneDriveException

Fixes #39, #44, #50, #55