### PR TITLE
Handle unsupported reauthentication exception

### DIFF
--- a/src/OneDriveSdk.WinStore/Authentication/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDriveSdk.WinStore/Authentication/OnlineIdAuthenticationProvider.cs
@@ -24,6 +24,8 @@ namespace Microsoft.OneDrive.Sdk
 {
     using System;
     using System.Linq;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading.Tasks;
     using Windows.Security.Authentication.OnlineId;
 
@@ -35,6 +37,26 @@ namespace Microsoft.OneDrive.Sdk
             : base(serviceInfo)
         {
             this.authenticator = new OnlineIdAuthenticator();
+        }
+
+        public override async Task AppendAuthHeaderAsync(HttpRequestMessage request)
+        {
+            // Reauthenticate only when the token expires.
+            if (this.CurrentAccountSession != null
+                && !string.IsNullOrEmpty(this.CurrentAccountSession.AccessToken)
+                && CurrentAccountSession.ExpiresOnUtc != DateTimeOffset.MinValue
+                && CurrentAccountSession.ExpiresOnUtc < DateTimeOffset.UtcNow)
+            {
+                await this.AuthenticateAsync();
+            }
+
+            if (this.CurrentAccountSession != null && !string.IsNullOrEmpty(this.CurrentAccountSession.AccessToken))
+            {
+                var tokenTypeString = string.IsNullOrEmpty(this.CurrentAccountSession.AccessTokenType)
+                    ? Constants.Headers.Bearer
+                    : this.CurrentAccountSession.AccessTokenType;
+                request.Headers.Authorization = new AuthenticationHeaderValue(Constants.Headers.Bearer, this.CurrentAccountSession.AccessToken);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fix #57 by verify if the token is expired before issuing the
re-authentication.