### PR TITLE
Added support for CredentialPromptType for UniversalClient.

### DIFF
--- a/src/OneDriveSdk.WinStore/Authentication/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDriveSdk.WinStore/Authentication/OnlineIdAuthenticationProvider.cs
@@ -23,6 +23,7 @@
 namespace Microsoft.OneDrive.Sdk
 {
     using System;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Windows.Security.Authentication.OnlineId;
@@ -64,7 +65,10 @@ namespace Microsoft.OneDrive.Sdk
             try
             {
                 var serviceTicketRequest = new OnlineIdServiceTicketRequest(string.Join(" ", this.ServiceInfo.Scopes), "DELEGATION");
-                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(serviceTicketRequest);
+                //                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(serviceTicketRequest);
+                var ticketRequests = new List<OnlineIdServiceTicketRequest>();
+                ticketRequests.Add(serviceTicketRequest);
+                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(ticketRequests, (Windows.Security.Authentication.OnlineId.CredentialPromptType) this.ServiceInfo.MicrosoftAccountPromptType);
 
                 var ticket = authenticationResponse.Tickets.FirstOrDefault();
 

--- a/src/OneDriveSdk.WinStore/Authentication/OnlineIdAuthenticationProvider.cs
+++ b/src/OneDriveSdk.WinStore/Authentication/OnlineIdAuthenticationProvider.cs
@@ -65,7 +65,6 @@ namespace Microsoft.OneDrive.Sdk
             try
             {
                 var serviceTicketRequest = new OnlineIdServiceTicketRequest(string.Join(" ", this.ServiceInfo.Scopes), "DELEGATION");
-                //                var authenticationResponse = await this.authenticator.AuthenticateUserAsync(serviceTicketRequest);
                 var ticketRequests = new List<OnlineIdServiceTicketRequest>();
                 ticketRequests.Add(serviceTicketRequest);
                 var authenticationResponse = await this.authenticator.AuthenticateUserAsync(ticketRequests, (Windows.Security.Authentication.OnlineId.CredentialPromptType) this.ServiceInfo.MicrosoftAccountPromptType);

--- a/src/OneDriveSdk.WinStore/Authentication/OnlineIdServiceInfoProvider.cs
+++ b/src/OneDriveSdk.WinStore/Authentication/OnlineIdServiceInfoProvider.cs
@@ -51,6 +51,7 @@ namespace Microsoft.OneDrive.Sdk
                 CredentialCache = credentialCache,
                 HttpProvider = httpProvider,
                 Scopes = appConfig.MicrosoftAccountScopes,
+                MicrosoftAccountPromptType = appConfig.MicrosoftAccountPromptType
             };
 
             microsoftAccountServiceInfo.AuthenticationProvider = this.AuthenticationProvider ?? new OnlineIdAuthenticationProvider(microsoftAccountServiceInfo);

--- a/src/OneDriveSdk.WinStore/Extensions/OneDriveClientExtensions.cs
+++ b/src/OneDriveSdk.WinStore/Extensions/OneDriveClientExtensions.cs
@@ -111,6 +111,7 @@ namespace Microsoft.OneDrive.Sdk
         /// </summary>
         /// <param name="scopes">The requested scopes for Microsoft account authentication.</param>
         /// <param name="httpProvider">The <see cref="IHttpProvider"/> for sending HTTP requests.</param>
+        /// <param name="promptType">The credential prompt type (show or hide the credential prompt user interface)</param>
         /// <returns>The <see cref="IOneDriveClient"/> for the session.</returns>
         public static IOneDriveClient GetClientUsingOnlineIdAuthenticator(
             string[] scopes,
@@ -170,6 +171,7 @@ namespace Microsoft.OneDrive.Sdk
         /// <param name="appId">The application ID for Microsoft account authentication.</param>
         /// <param name="scopes">The requested scopes for Microsoft account authentication.</param>
         /// <param name="httpProvider">The <see cref="IHttpProvider"/> for sending HTTP requests.</param>
+        /// <param name="promptType">The credential prompt type (show or hide the credential prompt user interface)</param>
         /// <returns>The <see cref="IOneDriveClient"/> for the session.</returns>
         public static IOneDriveClient GetUniversalClient(
             string[] scopes,

--- a/src/OneDriveSdk.WinStore/Extensions/OneDriveClientExtensions.cs
+++ b/src/OneDriveSdk.WinStore/Extensions/OneDriveClientExtensions.cs
@@ -115,10 +115,11 @@ namespace Microsoft.OneDrive.Sdk
         public static IOneDriveClient GetClientUsingOnlineIdAuthenticator(
             string[] scopes,
             string returnUrl = null,
-            IHttpProvider httpProvider = null)
+            IHttpProvider httpProvider = null,
+            CredentialPromptType promptType = CredentialPromptType.PromptIfNeeded)
         {
             return new OneDriveClient(
-                new AppConfig { MicrosoftAccountScopes = scopes },
+                new AppConfig { MicrosoftAccountScopes = scopes, MicrosoftAccountPromptType = promptType },
                 httpProvider: httpProvider ?? new HttpProvider(),
                 serviceInfoProvider: new OnlineIdServiceInfoProvider());
         }
@@ -173,9 +174,10 @@ namespace Microsoft.OneDrive.Sdk
         public static IOneDriveClient GetUniversalClient(
             string[] scopes,
             string returnUrl = null,
-            IHttpProvider httpProvider = null)
+            IHttpProvider httpProvider = null,
+            CredentialPromptType promptType = CredentialPromptType.PromptIfNeeded)
         {
-            return OneDriveClientExtensions.GetClientUsingOnlineIdAuthenticator(scopes, returnUrl, httpProvider);
+            return OneDriveClientExtensions.GetClientUsingOnlineIdAuthenticator(scopes, returnUrl, httpProvider, promptType);
         }
     }
 }

--- a/src/OneDriveSdk.WindowsForms/Web/FormsWebDialog.cs
+++ b/src/OneDriveSdk.WindowsForms/Web/FormsWebDialog.cs
@@ -52,6 +52,15 @@ namespace Microsoft.OneDrive.Sdk.WindowsForms
                 return null;
             }
 
+            bool isSignOutRequest =
+                requestUri.AbsoluteUri.StartsWith(Constants.Authentication.MicrosoftAccountSignOutUrl,
+                    StringComparison.OrdinalIgnoreCase) ||
+                requestUri.AbsoluteUri.StartsWith(Constants.Authentication.ActiveDirectorySignOutUrl,
+                    StringComparison.OrdinalIgnoreCase);
+
+            this.ShowInTaskbar = !isSignOutRequest;
+            this.WindowState = isSignOutRequest ? FormWindowState.Minimized : FormWindowState.Normal;
+
             this.RequestUri = requestUri;
             this.CallbackUri = callbackUri;
 

--- a/src/OneDriveSdk/Authentication/AppConfig.cs
+++ b/src/OneDriveSdk/Authentication/AppConfig.cs
@@ -68,5 +68,10 @@ namespace Microsoft.OneDrive.Sdk
         /// Gets or sets the requested scopes for Microsoft account authentication.
         /// </summary>
         public string[] MicrosoftAccountScopes { get; set; }
+
+        /// <summary>
+        /// Gets or sets the requested prompt type for Microsoft account authentication.
+        /// </summary>
+        public CredentialPromptType MicrosoftAccountPromptType { get; set; }
     }
 }

--- a/src/OneDriveSdk/Authentication/ServiceInfo.cs
+++ b/src/OneDriveSdk/Authentication/ServiceInfo.cs
@@ -113,5 +113,10 @@ namespace Microsoft.OneDrive.Sdk
         /// Gets or sets the <see cref="IWebAuthenticationUi"/> for displaying authentication UI to the user.
         /// </summary>
         public IWebAuthenticationUi WebAuthenticationUi { get; set; }
+
+        /// <summary>
+        /// Gets or sets the requested prompt type for Microsoft account authentication.
+        /// </summary>
+        public CredentialPromptType MicrosoftAccountPromptType { get; set; }
     }
 }

--- a/src/OneDriveSdk/Enums/CredentialPromptType.cs
+++ b/src/OneDriveSdk/Enums/CredentialPromptType.cs
@@ -1,0 +1,31 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) 2015 Microsoft Corporation
+// 
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+// 
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+// 
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.OneDrive.Sdk
+{
+    public enum CredentialPromptType
+    {
+        PromptIfNeeded = 0,
+        RetypeCredentials = 1,
+        DoNotPrompt = 2
+    }
+}

--- a/src/OneDriveSdk/OneDriveSdk.csproj
+++ b/src/OneDriveSdk/OneDriveSdk.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Constants.cs" />
     <Compile Include="Enums\AccountType.cs" />
     <Compile Include="Enums\ClientType.cs" />
+    <Compile Include="Enums\CredentialPromptType.cs" />
     <Compile Include="Enums\OneDriveErrorCode.cs" />
     <Compile Include="Exceptions\Error.cs" />
     <Compile Include="Exceptions\ErrorResponse.cs" />

--- a/src/OneDriveSdk/Requests/BaseRequest.cs
+++ b/src/OneDriveSdk/Requests/BaseRequest.cs
@@ -26,7 +26,6 @@ namespace Microsoft.OneDrive.Sdk
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Net;
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Reflection;
@@ -306,8 +305,8 @@ namespace Microsoft.OneDrive.Sdk
                         {
                             var segments = queryValue.Split('=');
                             return new QueryOption(
-                                WebUtility.UrlDecode(segments[0]),
-                                segments.Length > 1 ? WebUtility.UrlDecode(segments[1]) : string.Empty);
+                                segments[0],
+                                segments.Length > 1 ? segments[1] : string.Empty);
                         });
 
                 foreach(var queryOption in queryOptions)

--- a/tests/Test.OneDriveSdk/Requests/BaseRequestTests.cs
+++ b/tests/Test.OneDriveSdk/Requests/BaseRequestTests.cs
@@ -26,6 +26,7 @@ namespace Test.OneDriveSdk.Requests
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Net.Http;
     using System.Reflection;
     using System.Threading.Tasks;
@@ -51,6 +52,24 @@ namespace Test.OneDriveSdk.Requests
                 Assert.AreEqual("Base URL is not initialized for the request.", exception.Error.Message, "Unexpected error message.");
                 throw;
             }
+        }
+
+        [TestMethod]
+        public void BaseRequest_InitializeWithEncodedQueryString()
+        {
+            var baseUrl = string.Format(Constants.Authentication.OneDriveConsumerBaseUrlFormatString, "v1.0") + "/drive/items/id";
+            var secondQueryValue = WebUtility.UrlEncode("value2=value3&value4");
+            var query = string.Concat("?key=value&key2=", secondQueryValue);
+
+            var requestUrl = string.Concat(baseUrl, query);
+
+            var baseRequest = new BaseRequest(requestUrl, this.oneDriveClient);
+
+            Assert.AreEqual(new Uri(baseUrl), new Uri(baseRequest.RequestUrl), "Unexpected request URL.");
+            Assert.AreEqual(2, baseRequest.QueryOptions.Count, "Unexpected number of query options.");
+            Assert.IsTrue(baseRequest.QueryOptions[0].Name.Equals("key") && baseRequest.QueryOptions[0].Value.Equals("value"), "Unexpected first query option.");
+            Assert.IsTrue(baseRequest.QueryOptions[1].Name.Equals("key2") && baseRequest.QueryOptions[1].Value.Equals(secondQueryValue), "Unexpected second query option.");
+            Assert.AreEqual(0, baseRequest.Headers.Count, "Unexpected number of header options.");
         }
 
         [TestMethod]


### PR DESCRIPTION
This change resolves [AuthenticationFailure when trying to authenticate from Task #99](https://github.com/OneDrive/onedrive-sdk-csharp/issues/99), allowing authentication in UWP apps from non-UI threads by specifying DoNotPrompt as the CredentialPromptType.