### PR TITLE
Don't hard code app information in sample apps

### DIFF
--- a/samples/OneDriveApiBrowser/FormBrowser.cs
+++ b/samples/OneDriveApiBrowser/FormBrowser.cs
@@ -32,13 +32,13 @@ namespace OneDriveApiBrowser
 
     public partial class FormBrowser : Form
     {
-        private const string AadClientId = "67b8454b-58df-4e6d-a688-c769bd327052";
-        private const string AadReturnUrl = "https://localhost:777";
+        private const string AadClientId = "Insert your AAD client ID here";
+        private const string AadReturnUrl = "Insert your AAD return URL here";
 
-        private const string MsaClientId = "0000000044128B55";
+        private const string MsaClientId = "Insert your MSA client ID here";
         private const string MsaReturnUrl = "https://login.live.com/oauth20_desktop.srf";
 
-        private static readonly string[] Scopes = { "onedrive.readwrite", "wl.offline_access", "wl.signin" };
+        private static readonly string[] Scopes = { "onedrive.readwrite", "wl.signin" };
 
         private const int UploadChunkSize = 10 * 1024 * 1024;       // 10 MB
         private IOneDriveClient oneDriveClient { get; set; }

--- a/samples/OneDrivePhotoBrowser/AccountSelection.xaml.cs
+++ b/samples/OneDrivePhotoBrowser/AccountSelection.xaml.cs
@@ -36,11 +36,11 @@ namespace OneDrivePhotoBrowser
     /// </summary>
     public sealed partial class AccountSelection : Page
     {
-        private readonly string[] scopes = new string[] { "onedrive.readonly", "wl.offline_access", "wl.signin" };
+        private readonly string[] scopes = new string[] { "onedrive.readonly", "wl.signin" };
 
         // Set these values to your app's ID and return URL.
-        private readonly string oneDriveForBusinessAppId = "67b8454b-58df-4e6d-a688-c769bd327052";
-        private readonly string oneDriveForBusinessReturnUrl = "https://localhost:777";
+        private readonly string oneDriveForBusinessClientId = "Insert your AAD client ID here";
+        private readonly string oneDriveForBusinessReturnUrl = "Insert your AAD return URL here";
 
         public AccountSelection()
         {
@@ -64,7 +64,7 @@ namespace OneDrivePhotoBrowser
             }
 
             // Don't show AAD login if the required AAD auth values aren't set
-            if (string.IsNullOrEmpty(oneDriveForBusinessAppId) || string.IsNullOrEmpty(oneDriveForBusinessReturnUrl))
+            if (string.IsNullOrEmpty(oneDriveForBusinessClientId) || string.IsNullOrEmpty(oneDriveForBusinessReturnUrl))
             {
                 AadButton.Visibility = Visibility.Collapsed;
             }
@@ -87,7 +87,7 @@ namespace OneDrivePhotoBrowser
                 var client = clientType == ClientType.Consumer
                     ? OneDriveClientExtensions.GetUniversalClient(this.scopes) as OneDriveClient
                     : BusinessClientExtensions.GetActiveDirectoryClient(
-                        oneDriveForBusinessAppId,
+                        oneDriveForBusinessClientId,
                         oneDriveForBusinessReturnUrl) as OneDriveClient;
 
                 try

--- a/samples/OneDrivePhotoBrowser/readme.md
+++ b/samples/OneDrivePhotoBrowser/readme.md
@@ -16,7 +16,7 @@ To run the sample, you will need:
 ### Download the sample
 
 1. Download the sample from [GitHub](https://github.com/OneDrive/onedrive-sdk-csharp) by choosing **Clone in Desktop** or **Download Zip**. 
-3. In Visual Studio, open the **OneDriveSdk.sln** file and build it.
+2. In Visual Studio, open the **OneDriveSdk.sln** file and build it.
 
 ## OneDrive Consumer configuration
 
@@ -36,6 +36,8 @@ Replace the following values at the top of the file with your application detail
     private readonly string oneDriveForBusinessClientId = "Insert your AAD client ID here";
     private readonly string oneDriveForBusinessReturnUrl = "Insert your AAD return URL here";
 ```
+
+For more details on setting up an application to access OneDrive for Business please read the [registration documentation](https://dev.onedrive.com/app-registration.htm#register-your-app-for-onedrive-for-business) for the API.
 
 ## Run the sample
 

--- a/samples/OneDrivePhotoBrowser/readme.md
+++ b/samples/OneDrivePhotoBrowser/readme.md
@@ -18,9 +18,24 @@ To run the sample, you will need:
 1. Download the sample from [GitHub](https://github.com/OneDrive/onedrive-sdk-csharp) by choosing **Clone in Desktop** or **Download Zip**. 
 3. In Visual Studio, open the **OneDriveSdk.sln** file and build it.
 
+## OneDrive Consumer configuration
+
 ### Associate the sample app with the Windows Store
 
-Before you can run the sample, you must associate the app with the Windows Store. To do this, right-click the OneDrivePhotoBrowser project and choose **Store** | **Associate app with store**. Associating the app with the Windows store is reqiured for authentication to succeed.
+Before you can run the sample to use with OneDrive Consumer, you must associate the app with the Windows Store. To do this, right-click the OneDrivePhotoBrowser project and choose **Store** | **Associate app with store**. Associating the app with the Windows store is reqiured for authentication to succeed.
+
+OneDrive for Business authentication does not require store association.
+
+## OneDrive for Business configuration
+
+In order to authenticate using OneDrive for Business you'll need to enter your application details for the app. To do this, right-click the AccountSelection.xaml file and choose **View Code**.
+
+Replace the following values at the top of the file with your application details:
+
+```csharp
+    private readonly string oneDriveForBusinessClientId = "Insert your AAD client ID here";
+    private readonly string oneDriveForBusinessReturnUrl = "Insert your AAD return URL here";
+```
 
 ## Run the sample
 
@@ -34,24 +49,31 @@ The OneDrive Photo Browser sample app will open the signed-in user's personal On
 
 ### OneDrive sign-in
 
-In this sample app, authentication and sign in occurs when the app starts. If the user is not already signed in, the app will invoke the Microsoft account sign-in window.
+When the app loads, the user is presented with an account selection screen with two buttons: "Log in to MSA" and "Log in to AAD". If the user selects "Log in to MSA" the `GetUniversalClient` is called on the `OneDriveClientExtensions` object to get a `OneDriveClient` object. If the user selects "Log in to AAD" the `GetActiveDirectoryClient` is called on the `OneDriveClientExtensions` object to get a `OneDriveClient` object.
 
-In App.xaml.cs, an `IOneDriveClient` object is initialized.
-
-```csharp
-public IOneDriveClient OneDriveClient { get; set}
-```
-In MainPage.xaml.cs, sign-in is verified. If no user is signed in, a Microsoft account sign-in dialog appears. The `GetUniversalClient` is called on the `OneDriveClientExtensions` object to get a `OneDriveClient` object. Once a `OneDriveClient` object is returned, `AuthenticateAsync` completes the client authentication for the Windows Universal sample app.
+Once a `OneDriveClient` object is returned, `AuthenticateAsync` completes the client authentication for the Windows Universal sample app. This will prompt the user to log in with the selected account type.
 
 ```csharp
-private readonly string[] scopes = new string[] { "onedrive.readwrite", "wl.offline_access", "wl.signin" };
-...
-private async void MainPage_Loaded(object sender, RoutedEventArgs e)
+private async void InitializeClient(ClientType clientType, RoutedEventArgs e)
 {
   if (((App)Application.Current).OneDriveClient == null)
   {
-      ((App)Application.Current).OneDriveClient = OneDriveClientExtensions.GetUniversalClient(this.scopes);
-      await ((App)Application.Current).OneDriveClient.AuthenticateAsync();
+      var client = clientType == ClientType.Consumer
+          ? OneDriveClientExtensions.GetUniversalClient(this.scopes) as OneDriveClient
+          : BusinessClientExtensions.GetActiveDirectoryClient(
+              oneDriveForBusinessAppId,
+              oneDriveForBusinessReturnUrl) as OneDriveClient;
+              
+      try
+      {
+          await client.AuthenticateAsync();
+          ...
+      }
+      catch (OneDriveException exception)
+      {
+          ....
+          client.Dispose();
+      }
   }
   ...
 }

--- a/samples/OneDrivePhotoBrowser/readme.md
+++ b/samples/OneDrivePhotoBrowser/readme.md
@@ -10,7 +10,7 @@ The sample app displays only items that are images from a user's OneDrive. Note 
 To run the sample, you will need: 
 
 * Visual Studio 2013 or 2015, with Universal Windows App Development Tools **Note:** If you don't have Universal Windows App Development Tools installed, open **Control Panel** | **Uninstall a program**. Then right-click **Microsoft Visual Studio** and click **Change**. Select **Modify** and then choose **Universal Windows App Development Tools**. Click **Update**. For more info about setting up your machine for Universal Windows Platform development, see [Build UWP apps with Visual Studio](https://msdn.microsoft.com/en-us/library/windows/apps/dn609832.aspx).
-* A Microsoft account
+* A Microsoft account and/or Azure Active Directory account with access to OneDrive for Business
 * Knowledge of Windows Universal app development
 
 ### Download the sample
@@ -49,7 +49,7 @@ The OneDrive Photo Browser sample app will open the signed-in user's personal On
 
 ### OneDrive sign-in
 
-When the app loads, the user is presented with an account selection screen with two buttons: "Log in to MSA" and "Log in to AAD". If the user selects "Log in to MSA" the `GetUniversalClient` is called on the `OneDriveClientExtensions` object to get a `OneDriveClient` object. If the user selects "Log in to AAD" the `GetActiveDirectoryClient` is called on the `OneDriveClientExtensions` object to get a `OneDriveClient` object.
+When the app loads, the user is presented with an account selection screen with two buttons: "Log in to MSA" and "Log in to AAD". If the user selects "Log in to MSA" the `GetUniversalClient` is called on the `OneDriveClientExtensions` object to get a `OneDriveClient` object. If the user selects "Log in to AAD" the `GetActiveDirectoryClient` is called on the `BusinessClientExtensions` object to get a `OneDriveClient` object.
 
 Once a `OneDriveClient` object is returned, `AuthenticateAsync` completes the client authentication for the Windows Universal sample app. This will prompt the user to log in with the selected account type.
 


### PR DESCRIPTION
Updated sample apps not to use hard-coded application IDs and return URLs (except for the generic MSA desktop URL). Updated documentation for the sample apps to include setup steps for specifying application information and for AAD auth.

AAD application IDs are specific to tenant so the ID already present isn't usable. Requiring user to fill both ODC and ODB makes the pattern for both consistent. Fixes #66.

@rgregg, @peternied 