### PR TITLE
ChunkedUploadProvider with files >2GB and ItemByPath fixes.

### DIFF
--- a/src/OneDriveSdk/Helpers/ChunkedUploadProvider.cs
+++ b/src/OneDriveSdk/Helpers/ChunkedUploadProvider.cs
@@ -214,10 +214,10 @@ namespace Microsoft.OneDrive.Sdk.Helpers
 
         private int NextChunkSize(long rangeBegin, long rangeEnd)
         {
-            var sizeBasedOnRange = (int) (rangeEnd - rangeBegin) + 1;
+            var sizeBasedOnRange = (rangeEnd - rangeBegin) + 1;
             return sizeBasedOnRange > this.maxChunkSize
                 ? this.maxChunkSize
-                : sizeBasedOnRange;
+                : (int)sizeBasedOnRange;
         }
     }
 }

--- a/src/OneDriveSdk/Requests/Extensions/ItemRequestBuilderExtensions.cs
+++ b/src/OneDriveSdk/Requests/Extensions/ItemRequestBuilderExtensions.cs
@@ -9,11 +9,7 @@ namespace Microsoft.OneDrive.Sdk
     /// </summary>
     public partial class ItemRequestBuilder
     {
-        /// <summary>
-        /// Gets children request.
-        /// <returns>The children request.</returns>
-        /// </summary>
-        public IItemRequestBuilder ItemWithPath(string path)
+        internal static string PreparePath(string path)
         {
             if (!string.IsNullOrEmpty(path))
             {
@@ -21,10 +17,21 @@ namespace Microsoft.OneDrive.Sdk
                 {
                     path = string.Format("/{0}", path);
                 }
+
+                path = path.Replace("#", "%23");
             }
 
+            return path;
+        }
+
+        /// <summary>
+        /// Gets children request.
+        /// <returns>The children request.</returns>
+        /// </summary>
+        public IItemRequestBuilder ItemWithPath(string path)
+        {                     
             return new ItemRequestBuilder(
-                string.Format("{0}:{1}:", this.RequestUrl, path),
+                string.Format("{0}:{1}:", this.RequestUrl, PreparePath(path)),
                 this.Client);
         }
     }

--- a/src/OneDriveSdk/Requests/Extensions/OneDriveClientExtensions.cs
+++ b/src/OneDriveSdk/Requests/Extensions/OneDriveClientExtensions.cs
@@ -22,9 +22,9 @@ namespace Microsoft.OneDrive.Sdk
         /// <returns>The item request builder.</returns>
         /// </summary>
         public IItemRequestBuilder ItemWithPath(string path)
-        {
+        {                      
             return new ItemRequestBuilder(
-                string.Format("{0}{1}:", this.BaseUrl, path),
+                string.Format("{0}{1}:", this.BaseUrl, ItemRequestBuilder.PreparePath(path)),
                 this);
         }
     }

--- a/tests/Test.OneDriveSdk/Requests/ItemRequestTests.cs
+++ b/tests/Test.OneDriveSdk/Requests/ItemRequestTests.cs
@@ -111,6 +111,63 @@ namespace Test.OneDrive.Sdk.Requests
         }
 
         [TestMethod]
+        public void ItemByPath_BuildRequestWithHashtag()
+        {
+            var expectedRequestUri = new Uri("https://api.onedrive.com/v1.0/drive/root:/item/with/hashtag%23inpath:");
+            var itemRequestBuilder = this.oneDriveClient.Drive.Root.ItemWithPath("item/with/hashtag#inpath") as ItemRequestBuilder;            
+
+            Assert.IsNotNull(itemRequestBuilder, "Unexpected request builder.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequestBuilder.RequestUrl), "Unexpected request URL.");
+
+            var itemRequest = itemRequestBuilder.Request() as ItemRequest;
+            Assert.IsNotNull(itemRequest, "Unexpected request.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequest.RequestUrl), "Unexpected request URL.");
+        }
+
+
+        [TestMethod]
+        public void OneDriveClient_ItemByPath_BuildRequest()
+        {
+            var expectedRequestUri = new Uri("https://api.onedrive.com/v1.0/drive/root:/item/with/path:");
+            var itemRequestBuilder = this.oneDriveClient.ItemWithPath("drive/root:/item/with/path") as ItemRequestBuilder;
+
+            Assert.IsNotNull(itemRequestBuilder, "Unexpected request builder.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequestBuilder.RequestUrl), "Unexpected request URL.");
+
+            var itemRequest = itemRequestBuilder.Request() as ItemRequest;
+            Assert.IsNotNull(itemRequest, "Unexpected request.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequest.RequestUrl), "Unexpected request URL.");
+        }
+
+        [TestMethod]
+        public void OneDriveClient_ItemByPath_BuildRequestWithLeadingSlash()
+        {
+            var expectedRequestUri = new Uri("https://api.onedrive.com/v1.0/drive/root:/item/with/path:");
+            var itemRequestBuilder = this.oneDriveClient.ItemWithPath("/drive/root:/item/with/path") as ItemRequestBuilder;
+
+            Assert.IsNotNull(itemRequestBuilder, "Unexpected request builder.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequestBuilder.RequestUrl), "Unexpected request URL.");
+
+            var itemRequest = itemRequestBuilder.Request() as ItemRequest;
+            Assert.IsNotNull(itemRequest, "Unexpected request.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequest.RequestUrl), "Unexpected request URL.");
+        }
+
+        [TestMethod]
+        public void OneDriveClient_ItemByPath_BuildRequestWithHashtag()
+        {
+            var expectedRequestUri = new Uri("https://api.onedrive.com/v1.0/drive/root:/item/with/hashtag%23inpath:");            
+            var itemRequestBuilder = this.oneDriveClient.ItemWithPath("drive/root:/item/with/hashtag#inpath") as ItemRequestBuilder;
+
+            Assert.IsNotNull(itemRequestBuilder, "Unexpected request builder.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequestBuilder.RequestUrl), "Unexpected request URL.");
+
+            var itemRequest = itemRequestBuilder.Request() as ItemRequest;
+            Assert.IsNotNull(itemRequest, "Unexpected request.");
+            Assert.AreEqual(expectedRequestUri, new Uri(itemRequest.RequestUrl), "Unexpected request URL.");
+        }
+
+        [TestMethod]
         public async Task ItemRequest_CreateAsync()
         {
             await this.RequestWithItemInBody(false);


### PR DESCRIPTION
A bug was fixed in the ChunkedUploadProvider which caused it to miscalculate the chunksizes when the file was larger than Int32.Max bytes.

Both the ItemRequestBuilder.ItemWithPath and the OneDriveClient.ItemWithPath methods incorrectly encoded the Uri when a hashtag character was in the path, resulting in an "API not found" error.

A Unit Test was added for the ItemWithPath situation and additional Unit Tests were added to validate the OneDriveClient.ItemWithPath method is working as expected.