### PR TITLE
items.md - wrong sample code, ".Drive" is missing

### DIFF
--- a/docs/items.md
+++ b/docs/items.md
@@ -20,6 +20,7 @@ Get an Item
 
 ```csharp
 var item = await oneDriveClient
+                     .Drive
                      .Items[itemId]
                      .Request()
                      .GetAsync();


### PR DESCRIPTION
Calling ".Drive" is missing in Get by ID sample code